### PR TITLE
Make uid label configurable

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -131,10 +131,14 @@ module OmniAuth
       # default 値: :basic
       option :client_auth_method
 
+      # Any field from user_info to be processed as UID
+      option :uid_field, 'sub'
 
       attr_accessor :access_token
 
-      uid { user_info.sub }
+      uid do
+	user_info.send(options.uid_field.to_s)
+      end
 
       info do
         {


### PR DESCRIPTION
The uid is always using the sub value from the *userinfo*, which in some applications is not the expected value.

To avoid such limitations, the uid label is now configurable by configuring the omniauth *uid_label* option to a different label that apears in the userinfo details.

The default value for *uid_label* is set to *sub* to ensure the backward compatibility is not broken.