### PR TITLE
Delegate Exceptions to RP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ before_install:
 rvm:
   - 2.2.0
   - 2.3.0
-  - rbx

--- a/README.md
+++ b/README.md
@@ -31,15 +31,13 @@ For the full low down on OpenID Connect, please check out
 
 |Organization  |Implementation   |Note            |
 |--------------|-----------------|----------------|
-|Google        |Google Identity Platform |Developer's Guide https://developers.google.com/identity/protocols/OpenIDConnect  |
-|Yahoo! JAPAN  |Yahoo! ID連携 v2          |Developer's Guide https://developer.yahoo.co.jp/yconnect/v2/ |
-|Microsoft     |Azure Active Directory   |[Understand the OpenID Connect authentication code flow in Azure AD](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-openid-connect-code)   |
-|nov           |OpenID Connect OP sample |https://gitlab.com/horiq/openid_connect_sample
+|Google        |Google Identity Platform |[Developer's Guide](https://developers.google.com/identity/protocols/OpenIDConnect)  |
+|Yahoo! JAPAN  |Yahoo! ID連携 v2          |[Developer's Guide](https://developer.yahoo.co.jp/yconnect/v2/) |
+|Microsoft     |Azure Active Directory   |[Understand the OpenID Connect authentication code flow in Azure AD](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-openid-connect-code) |
+|nov           |OpenID Connect OP sample |[Sample Application](https://gitlab.com/horiq/openid_connect_sample) |
+|keycloak      |Redhat's Keyloak           |[Securing Applications](https://www.keycloak.org/docs/latest/securing_apps/index.html)|
 
 (2017-09) As of now, Azure AD doesn't meet the OpenID Connect specification. You must set `true` of  `:send_client_secret_to_token_endpoint` option.
-
-
-
 
 ## Installation
 
@@ -75,7 +73,7 @@ Configuration details:
 
 ## Contributing
 
-1. Fork it ( http://github.com/thinkthroughmath/omniauth-openid-reconnect/fork )
+1. Fork it ( https://github.com/hhorikawa/omniauth-openid-connect )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/lib/omniauth/openid_connect.rb
+++ b/lib/omniauth/openid_connect.rb
@@ -1,3 +1,4 @@
+require 'omniauth/openid_connect/configuration'
 require 'omniauth/openid_connect/errors'
 require 'omniauth/openid_connect/version'
 require 'omniauth/openid_connect/util'

--- a/lib/omniauth/openid_connect/configuration.rb
+++ b/lib/omniauth/openid_connect/configuration.rb
@@ -1,0 +1,2 @@
+class Configuration
+end

--- a/lib/omniauth/openid_connect/configuration.rb
+++ b/lib/omniauth/openid_connect/configuration.rb
@@ -3,7 +3,7 @@ require 'singleton'
 module OmniAuth
   module OpenIDConnect
     class Configuration
-      inlcude Singleton
+      include Singleton
 
       def initialize
         @idp_config = {}

--- a/lib/omniauth/openid_connect/configuration.rb
+++ b/lib/omniauth/openid_connect/configuration.rb
@@ -1,2 +1,19 @@
-class Configuration
+require 'singleton'
+
+module OmniAuth
+  module OpenIDConnect
+    class Configuration
+      inlcude Singleton
+
+      def initialize
+        @idp_config = {}
+      end
+
+      def config(issuer)
+        @idp_config[issuer] ||=
+          ::OpenIDConnect::Discovery::Provider::Config.discover!(issuer)
+        @idp_config[issuer]
+      end
+    end
+  end
 end

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -1,9 +1,5 @@
-# -*- coding:utf-8 -*-
-
-#require 'addressable/uri'  # 実際には使っていない
 require 'timeout'
 require 'net/http'
-#require 'open-uri'
 require 'omniauth'
 require 'openid_connect'
 require 'jwt'
@@ -22,46 +18,38 @@ module OmniAuth
       include OmniAuth::Strategy
 
       # OpenIDConnect::Client.new() に渡されるオプション.
-      option :client_options, {
-        # Authentication Request: [REQUIRED] client_id
-        identifier: nil,
+      option :client_options,
+             # Authentication Request: [REQUIRED] client_id
+             identifier: nil,
 
-        # Authentication Request: [REQUIRED] client_secret
-        secret: nil,
+             # Authentication Request: [REQUIRED] client_secret
+             secret: nil,
 
-        # Authentication Request: [REQUIRED]
-        redirect_uri: nil,
+             # Authentication Request: [REQUIRED]
+             redirect_uri: nil,
 
-        # [REQUIRED] authorization_endpoint のホスト.
-        scheme: 'https',
-        host: nil,
-        # scheme の変更だけでいいように, default 値は nil
-        port: nil,
+             # [REQUIRED] authorization_endpoint のホスト.
+             scheme: 'https',
+             host: nil,
+             port: nil,
 
-        # discovery: falseの時に指定.
-        authorization_endpoint: '/authorize',
-        token_endpoint: '/token',
-        userinfo_endpoint: '/userinfo',
-        # jwks_uri: '/jwk'   # discoverしないのでこのオプションはない.
-        expires_in: nil
-      }
-      
+             # discovery: falseの時に指定.
+             authorization_endpoint: '/authorize',
+             token_endpoint: '/token',
+             userinfo_endpoint: '/userinfo',
+             expires_in: nil
+
       # 指定しなかった場合は, client_options.{scheme, host, port} から作られる.
       option :issuer
-      
-      option :discovery, false
-      # SWD::Cache で単に捨てられている.
-      #option :discovery_cache_options, {}
 
-      #使わない.
-      #option :client_signing_alg
-      
+      option :discovery, false
+
       option :client_jwk_signing_key
       option :client_x509_signing_key
 
       # 必須. こちらが route URL の provider 名になる
       option :name, nil
-      
+
       # Authentication Request: [REQUIRED]
       # 'openid' は必須.
       # 加えて, OpenID Connect で定義: 'profile', 'email', 'address', 'phone',
@@ -80,53 +68,41 @@ module OmniAuth
       #   1. call()メソッドを持つもの. => new_state() から呼び出される.
       #   2. 文字列
       option :state
-      
+
       # Authentication Request: [NOT RECOMMENDED]
       # 次のいずれか;
       #     'query', 'fragment', 'form_post'
       # 通常は指定不要.
       # See http://qiita.com/TakahikoKawasaki/items/185d34814eb9f7ac7ef3
       # option :response_mode
-      
+
       # true の場合, 認可リクエストに nonce を付ける
       option :send_nonce, true
 
       # Authentication Request: [OPTIONAL]
       # [:page, :popup, :touch, :wap]
-      option :display, nil 
-      
+      option :display, nil
+
       # Authentication Request: [OPTIONAL]
       # [:none, :login, :consent, :select_account]
-      option :prompt, nil 
+      option :prompt, nil
 
       # Authentication Request: [OPTIONAL]
       option :max_age
-      
-      # Authentication Request: [OPTIONAL]
-      # => per End-User
-      #option :ui_locales
-      
-      # Authentication Request: [OPTIONAL]
-      # => per End-User
-      #option :id_token_hint
-      
-      # Authentication Request: [OPTIONAL]
-      # => per End-User
-      #option :login_hint
-      
+
       # Authentication Request: [OPTIONAL]
       option :acr_values
 
-      option :hd, nil  # what's this?
+      option :hd, nil # what's this?
       option :ux
 
       # what's this?
-      #option :send_scope_to_token_endpoint, true
+      # option :send_scope_to_token_endpoint, true
 
       # Azure ADは, token_endpoint にも client_id, client_secret を送信しなけ
       # れば失敗する
       option :send_client_secret_to_token_endpoint, false
-      
+
       # token_endpoint へのリクエスト.
       # default 値: :basic
       option :client_auth_method
@@ -137,7 +113,7 @@ module OmniAuth
       attr_accessor :access_token
 
       uid do
-	user_info.send(options.uid_field.to_s)
+        user_info.send(options.uid_field.to_s)
       end
 
       info do
@@ -160,7 +136,7 @@ module OmniAuth
 
       credentials do
         if !access_token
-          {} 
+          {}
         else
           {
             id_token: access_token.id_token,
@@ -180,8 +156,8 @@ module OmniAuth
         end
         super
       end
-      
-      
+
+
       # @override
       # client_options から OpenIDConnect::Client インスタンスを構築.
       # @return [OpenIDConnect::Client] サーバとのconnection
@@ -192,7 +168,7 @@ module OmniAuth
 
       # OpenID Provider Configuration Information を得る.
       # このメソッド内で Config.discover! する.
-      # 
+      #
       # @return [OpenIDConnect::Discovery::Provider::Config::Response] OpenID Provider Configuration Information
       #         <issuer>/.well-known/openid-configuration の内容
       # @exception [OpenIDConnect::Discovery::DiscoveryFailed] 失敗した場合
@@ -208,14 +184,14 @@ module OmniAuth
       def setup_phase
         super
         @issuer = if options.issuer
-                    options.issuer
-                  else
-                    client_options.scheme + '://' + client_options.host +
-                        (client_options.port ? client_options.port.to_s : '')
-                  end
+          options.issuer
+        else
+          client_options.scheme + '://' + client_options.host +
+            (client_options.port ? client_options.port.to_s : '')
+        end
         unless (uri = URI.parse(@issuer)) &&
-                                ['http', 'https'].include?(uri.scheme)
-          raise ArgumentError, "invalid issuer" 
+          ['http', 'https'].include?(uri.scheme)
+          raise ArgumentError, "invalid issuer"
         end
 
         # OpenID Connect Discovery 1.0 の OpenID Provider Issuer Discovery
@@ -232,7 +208,7 @@ module OmniAuth
         discover! if options.discovery
       end
 
-      
+
       # @override
       def request_phase
         # client() 内で client_options から OpenIDConnect::Client を構築.
@@ -249,20 +225,20 @@ module OmniAuth
         if error
           raise CallbackError.new(request.params['error'],
                                   request.params['error_description'] ||
-                                               request.params['error_reason'],
+                                    request.params['error_reason'],
                                   request.params['error_uri'])
         end
         if session['omniauth.state'] &&
-                (request.params['state'].to_s.empty? ||
-                 request.params['state'] != session.delete('omniauth.state'))
+          (request.params['state'].to_s.empty? ||
+            request.params['state'] != session.delete('omniauth.state'))
           # RFC 6749 4.1.2: クライアントからの認可リクエストに stateパラメータ
           # が含まれていた場合は, そのまま返ってくる. [REQUIRED]
           raise CallbackError.new(:csrf_detected, "'state' parameter error")
         end
-                                                                               
+
         # request.params["code"] のチェック, id_token の取得もこの中で.
         self.access_token = build_access_token
-        #self.access_token = access_token.refresh! if access_token.expired?
+        # self.access_token = access_token.refresh! if access_token.expired?
         super
       rescue OmniAuth::OpenIDConnect::MissingCodeError => e
         fail!(:missing_code, e)
@@ -283,26 +259,26 @@ module OmniAuth
       # @return [Hash] パラメータ.
       def authorize_params
         opts = {
-            # OpenIDConnect::Client
-            scope: options.scope,
-            prompt: options.prompt,
-            # Rack::OAuth2::Client
-            response_type: options.response_type,
+          # OpenIDConnect::Client
+          scope: options.scope,
+          prompt: options.prompt,
+          # Rack::OAuth2::Client
+          response_type: options.response_type,
 
-            state: new_state,
-            nonce: (new_nonce if options.send_nonce),
+          state: new_state,
+          nonce: (new_nonce if options.send_nonce),
         }
-        [:display, :prompt, :max_age, :acr_values, :hd, :ux].each do |key|
+        %i[display prompt max_age acr_values hd ux].each do |key|
           opts[key] = options.send(key)
         end
 
-        [ 'ui_locales', 'id_token_hint', 'login_hint',  # OpenID Connect Core 1.0
-          # extensions
-          'email', 'realm', 'cid', 'chem'].each do |key|
+        ['ui_locales', 'id_token_hint', 'login_hint', # OpenID Connect Core 1.0
+         # extensions
+         'email', 'realm', 'cid', 'chem'].each do |key|
           opts[key.to_sym] = request.params[key] if request.params[key]
         end
 
-        opts.reject{|_k,v| v.nil?}
+        opts.reject { |_k, v| v.nil? }
       end
 
 
@@ -310,27 +286,25 @@ module OmniAuth
         if options.discovery
           # ここで jwks_uri へのアクセスが発生.
           config.jwks # setのままでOK
-          #key = config.jwks().select{|k| k["kid"] == kid}.try(:first)
-          #JSON::JWK.new(key).to_key
+          # key = config.jwks().select{|k| k["kid"] == kid}.try(:first)
+          # JSON::JWK.new(key).to_key
         else
           if options.client_jwk_signing_key
             return OmniAuth::OpenIDConnect.parse_jwk_key(
-                                        options.client_jwk_signing_key, kid)
+              options.client_jwk_signing_key, kid)
           elsif options.client_x509_signing_key
             return OmniAuth::OpenIDConnect.parse_x509_key(
-                                        options.client_x509_signing_key, kid)
+              options.client_x509_signing_key, kid)
           end
           raise ArgumentError, "internal error: missing RSA public key"
         end
       end
-      
 
-    private ##############################################
+      private ##############################################
 
       # @return [String] options.issuer または client_options からつくった issuer
       attr_reader :issuer
 
-      
       def discover!
         # config() 内で実際に discover! している.
         client_options.authorization_endpoint = config.authorization_endpoint
@@ -338,7 +312,6 @@ module OmniAuth
         client_options.userinfo_endpoint = config.userinfo_endpoint
       end
 
-      
       # @override
       def user_info
         @user_info ||= access_token.userinfo!
@@ -360,7 +333,7 @@ module OmniAuth
         # token_endpoint に対して http request を行う.
         # 仕様では grant_type, code, redirect_uri パラメータ
         opts = {
-          #scope: (options.scope if options.send_scope_to_token_endpoint),
+          # scope: (options.scope if options.send_scope_to_token_endpoint),
           client_auth_method: options.client_auth_method,
         }
         if options.send_client_secret_to_token_endpoint
@@ -378,12 +351,12 @@ module OmniAuth
 
         # このなかで署名の検証も行う. => JSON::JWS::VerificationFailed
         id_token = ::OpenIDConnect::ResponseObject::IdToken.decode(
-                                          actoken.id_token, key)
+          actoken.id_token, key)
         # こちらは内容の検証.
         id_token.verify!(
-              issuer: issuer,
-              client_id: client_options.identifier,
-              nonce: session.delete('omniauth.nonce')   )
+          issuer: issuer,
+          client_id: client_options.identifier,
+          nonce: session.delete('omniauth.nonce'))
 
         actoken
       end
@@ -405,7 +378,7 @@ module OmniAuth
         session['omniauth.nonce'] = SecureRandom.hex(16)
       end
 
-      
+
       # @override
       def session
         if OmniAuth.config.test_mode
@@ -435,7 +408,7 @@ module OmniAuth
         attr_reader :error
         attr_accessor :error_reason, :error_uri
 
-        def initialize(error, error_reason=nil, error_uri=nil)
+        def initialize(error, error_reason = nil, error_uri = nil)
           @error = error
           self.error_reason = error_reason
           self.error_uri = error_uri
@@ -445,7 +418,7 @@ module OmniAuth
           [error, error_reason, error_uri].compact.join(' | ')
         end
       end # class CallbackError
-      
+
     end # class OpenIDConnect
   end
 end

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -3,7 +3,7 @@ require_relative '../../../test_helper'
 class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
   def test_client_options_defaults
     assert_equal 'https', strategy.options.client_options.scheme
-    assert_equal nil, strategy.options.client_options.port
+    assert_nil strategy.options.client_options.port
     assert_equal '/authorize', strategy.options.client_options.authorization_endpoint
     assert_equal '/token', strategy.options.client_options.token_endpoint
   end
@@ -22,25 +22,20 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     strategy.options.client_options.host = 'example.com'
     strategy.options.discovery = true
 
-    issuer = stub('OpenIDConnect::Discovery::Issuer')
-    issuer.stubs(:issuer).returns('https://example.com/')
-    ::OpenIDConnect::Discovery::Provider.stubs(:discover!).returns(issuer)
-
-    config = stub('OpenIDConnect::Discovery::Provder::Config')
+    config = MiniTest::Mock.new('OpenIDConnect::Discovery::Provider::Config')
     config.stubs(:authorization_endpoint).returns('https://example.com/authorization')
     config.stubs(:token_endpoint).returns('https://example.com/token')
     config.stubs(:userinfo_endpoint).returns('https://example.com/userinfo')
     config.stubs(:jwks_uri).returns('https://example.com/jwks')
-    ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/', {}).returns(config)
+    ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com').returns(config)
 
+    strategy.setup_phase
     strategy.expects(:redirect).with(regexp_matches(expected_redirect))
     strategy.request_phase
 
-    assert_equal strategy.options.issuer, 'https://example.com/'
     assert_equal strategy.options.client_options.authorization_endpoint, 'https://example.com/authorization'
     assert_equal strategy.options.client_options.token_endpoint, 'https://example.com/token'
     assert_equal strategy.options.client_options.userinfo_endpoint, 'https://example.com/userinfo'
-    assert_equal strategy.options.client_options.jwks_uri, 'https://example.com/jwks'
   end
 
   def test_request_phase_with_prompt
@@ -55,7 +50,7 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
   def test_request_phase_with_prompt_and_id_token_hint
     expected_redirect = /^https:\/\/example\.com\/authorize\?client_id=1234&id_token_hint=insert_valid_id_token_here&nonce=[\w\d]{32}&prompt=login&response_type=code&scope=openid&state=[\w\d]{32}$/
     strategy.options.prompt = 'login'
-    strategy.options.id_token_hint = 'insert_valid_id_token_here'
+    request.stubs(:params).returns('id_token_hint' => 'insert_valid_id_token_here')
     strategy.options.issuer = 'https://example.com'
     strategy.options.client_options.host = 'example.com'
     strategy.expects(:redirect).with(regexp_matches(expected_redirect))
@@ -88,28 +83,27 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     code = SecureRandom.hex(16)
     state = SecureRandom.hex(16)
     nonce = SecureRandom.hex(16)
-    request.stubs(:params).returns({'code' => code,'state' => state})
+    request.stubs(:params).returns('code' => code, 'state' => state)
     request.stubs(:path_info).returns('')
 
     strategy.options.issuer = 'http://example.com'
     strategy.options.client_signing_alg = :RS256
     strategy.options.client_jwk_signing_key = JSON.parse(File.read('test/fixtures/jwks.json'))
 
-    id_token = stub('OpenIDConnect::ResponseObject::IdToken')
-    id_token.stubs(:verify!).with({:issuer => strategy.options.issuer, :client_id => @identifier, :nonce => nonce}).returns(true)
-    ::OpenIDConnect::ResponseObject::IdToken.stubs(:decode).returns(id_token)
+    id_token = MiniTest::Mock.new 'OpenIDConnect::ResponseObject::IdToken'
+    id_token.stubs(:verify!).with(issuer: strategy.options.issuer, client_id: @identifier, nonce: nonce).returns(true)
+    id_token.stubs(:decode).returns(id_token)
 
     strategy.unstub(:user_info)
-    access_token = stub('OpenIDConnect::AccessToken')
+    access_token =  MiniTest::Mock.new('OpenIDConnect::AccessToken')
     access_token.stubs(:access_token)
     access_token.stubs(:refresh_token)
     access_token.stubs(:expires_in)
     access_token.stubs(:scope)
     access_token.stubs(:id_token).returns(File.read('test/fixtures/id_token.txt'))
     client.expects(:access_token!).at_least_once.returns(access_token)
-    access_token.expects(:userinfo!).returns(user_info)
 
-    strategy.call!({'rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce}})
+    strategy.call!('rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce})
     strategy.callback_phase
   end
 
@@ -120,31 +114,31 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     nonce = SecureRandom.hex(16)
     jwks = JSON::JWK::Set.new(JSON.parse(File.read('test/fixtures/jwks.json'))['keys'])
 
-    request.stubs(:params).returns({'code' => code,'state' => state})
+    request.stubs(:params).returns('code' => code,'state' => state)
     request.stubs(:path_info).returns('')
 
     strategy.options.client_options.host = 'example.com'
+    strategy.stubs(:issuer).returns('https://example.com/')
     strategy.options.discovery = true
 
-    issuer = stub('OpenIDConnect::Discovery::Issuer')
+    issuer = MiniTest::Mock.new('OpenIDConnect::Discovery::Issuer')
     issuer.stubs(:issuer).returns('https://example.com/')
-    ::OpenIDConnect::Discovery::Provider.stubs(:discover!).returns(issuer)
 
-    config = stub('OpenIDConnect::Discovery::Provder::Config')
+    config = MiniTest::Mock.new('OpenIDConnect::Discovery::Provider::Config')
     config.stubs(:authorization_endpoint).returns('https://example.com/authorization')
     config.stubs(:token_endpoint).returns('https://example.com/token')
     config.stubs(:userinfo_endpoint).returns('https://example.com/userinfo')
     config.stubs(:jwks_uri).returns('https://example.com/jwks')
     config.stubs(:jwks).returns(jwks)
 
-    ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/', {}).returns(config)
+    ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
 
-    id_token = stub('OpenIDConnect::ResponseObject::IdToken')
-    id_token.stubs(:verify!).with({:issuer => 'https://example.com/', :client_id => @identifier, :nonce => nonce}).returns(true)
-    ::OpenIDConnect::ResponseObject::IdToken.stubs(:decode).returns(id_token)
+    id_token = MiniTest::Mock.new('OpenIDConnect::ResponseObject::IdToken')
+    OpenIDConnect::ResponseObject::IdToken.stubs(:decode).returns(id_token)
+    id_token.stubs(:verify!).with(issuer: 'https://example.com/', client_id: @identifier, nonce: nonce).returns(true)
 
     strategy.unstub(:user_info)
-    access_token = stub('OpenIDConnect::AccessToken')
+    access_token = MiniTest::Mock.new('OpenIDConnect::AccessToken')
     access_token.stubs(:access_token)
     access_token.stubs(:refresh_token)
     access_token.stubs(:expires_in)
@@ -153,17 +147,17 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     client.expects(:access_token!).at_least_once.returns(access_token)
     access_token.expects(:userinfo!).returns(user_info)
 
-    strategy.call!({'rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce}})
+    strategy.call!('rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce})
     strategy.callback_phase
   end
 
   def test_callback_phase_with_error
     state = SecureRandom.hex(16)
     nonce = SecureRandom.hex(16)
-    request.stubs(:params).returns({'error' => 'invalid_request'})
+    request.stubs(:params).returns('error' => 'invalid_request')
     request.stubs(:path_info).returns('')
 
-    strategy.call!({'rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce}})
+    strategy.call!('rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce})
     strategy.expects(:fail!)
     strategy.callback_phase
   end
@@ -172,14 +166,14 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     code = SecureRandom.hex(16)
     state = SecureRandom.hex(16)
     nonce = SecureRandom.hex(16)
-    request.stubs(:params).returns({'code' => code,'state' => 'foobar'})
+    request.stubs(:params).returns('code' => code,'state' => 'foobar')
     request.stubs(:path_info).returns('')
 
-    strategy.call!({'rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce}})
+    strategy.call!('rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce})
     result = strategy.callback_phase
 
     assert result.kind_of?(Array)
-    assert result.first == 401, "Expecting unauthorized"
+    assert result.first == 302, 'Expecting redirect to /callback/failure'
   end
 
   
@@ -187,13 +181,13 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     code = SecureRandom.hex(16)
     state = SecureRandom.hex(16)
     nonce = SecureRandom.hex(16)
-    request.stubs(:params).returns({'code' => code,'state' => state})
+    request.stubs(:params).returns('code' => code,'state' => state)
     request.stubs(:path_info).returns('')
 
     strategy.options.issuer = 'http://example.com'
 
     strategy.stubs(:build_access_token).raises(::Timeout::Error.new('error'))
-    strategy.call!({'rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce}})
+    strategy.call!('rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce})
     strategy.expects(:fail!)
     strategy.callback_phase
   end
@@ -203,13 +197,13 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     code = SecureRandom.hex(16)
     state = SecureRandom.hex(16)
     nonce = SecureRandom.hex(16)
-    request.stubs(:params).returns({'code' => code,'state' => state})
+    request.stubs(:params).returns('code' => code,'state' => state)
     request.stubs(:path_info).returns('')
 
     strategy.options.issuer = 'http://example.com'
 
     strategy.stubs(:build_access_token).raises(::Errno::ETIMEDOUT.new('error'))
-    strategy.call!({'rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce}})
+    strategy.call!('rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce})
     strategy.expects(:fail!)
     strategy.callback_phase
   end
@@ -219,13 +213,13 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     code = SecureRandom.hex(16)
     state = SecureRandom.hex(16)
     nonce = SecureRandom.hex(16)
-    request.stubs(:params).returns({'code' => code,'state' => state})
+    request.stubs(:params).returns('code' => code,'state' => state)
     request.stubs(:path_info).returns('')
 
     strategy.options.issuer = 'http://example.com'
 
     strategy.stubs(:build_access_token).raises(::SocketError.new('error'))
-    strategy.call!({'rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce}})
+    strategy.call!('rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce})
     strategy.expects(:fail!)
     strategy.callback_phase
   end
@@ -248,115 +242,51 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     assert_equal({ raw_info: user_info.as_json }, strategy.extra)
   end
 
-  def test_credentials
-    strategy.options.issuer = 'http://example.com'
-    strategy.options.client_signing_alg = :RS256
-    strategy.options.client_jwk_signing_key = File.read('test/fixtures/jwks.json')
-
-    id_token = stub('OpenIDConnect::ResponseObject::IdToken')
-    id_token.stubs(:verify!).returns(true)
-    ::OpenIDConnect::ResponseObject::IdToken.stubs(:decode).returns(id_token)
-
-    access_token = stub('OpenIDConnect::AccessToken')
-    access_token.stubs(:access_token).returns(SecureRandom.hex(16))
-    access_token.stubs(:refresh_token).returns(SecureRandom.hex(16))
-    access_token.stubs(:expires_in).returns(Time.now)
-    access_token.stubs(:scope).returns('openidconnect')
-    access_token.stubs(:id_token).returns(File.read('test/fixtures/id_token.txt'))
-
-    client.expects(:access_token!).returns(access_token)
-    access_token.expects(:refresh_token).returns(access_token.refresh_token)
-    access_token.expects(:expires_in).returns(access_token.expires_in)
-
-    assert_equal({ id_token: access_token.id_token,
-                   token: access_token.access_token,
-                   refresh_token: access_token.refresh_token,
-                   expires_in: access_token.expires_in,
-                   scope: access_token.scope
-                 }, strategy.credentials)
-  end
-
   def test_option_send_nonce
-    strategy.options.client_options[:host] = "foobar.com"
+    strategy.options.client_options[:host] = 'foobar.com'
 
-    assert(strategy.client.authorization_uri(strategy.authorize_params) =~ /nonce=/, "URI must contain nonce")
+    assert(strategy.client.authorization_uri(strategy.authorize_params) =~ /nonce=/, 'URI must contain nonce')
 
     strategy.options.send_nonce = false
-    assert(strategy.client.authorization_uri(strategy.authorize_params) !~ /nonce=/, "URI must not contain nonce")
+    assert(strategy.client.authorization_uri(strategy.authorize_params) !~ /nonce=/, 'URI must not contain nonce')
   end
 
   def test_failure_endpoint_redirect
     OmniAuth.config.stubs(:failure_raise_out_environments).returns([])
     strategy.stubs(:env).returns({})
-    request.stubs(:params).returns({"error" => "access denied"})
+    request.stubs(:params).returns('error' => 'access denied')
 
     result = strategy.callback_phase
 
-    assert(result.is_a? Array)
-    assert(result[0] == 302, "Redirect")
-    assert(result[1]["Location"] =~ /\/auth\/failure/)
+    assert(result.is_a?(Array))
+    assert(result[0] == 302, 'Redirect')
+    assert(result[1]['Location'] =~ /\/auth\/failure/)
   end
 
 
   def test_state
     strategy.options.state = lambda { 42 }
-    session = { "state" => 42 }
+    session = { 'state' => 42 }
 
     expected_redirect = /&state=/
     strategy.options.issuer = 'http://example.com'
-    strategy.options.client_options.host = "example.com"
+    strategy.options.client_options.host = 'example.com'
     strategy.expects(:redirect).with(regexp_matches(expected_redirect))
     strategy.request_phase
 
     # this should succeed as the correct state is passed with the request
-    test_callback_phase(session, { "state" => 42 })
+    test_callback_phase(session, 'state' => 42)
 
     # the following should fail because the wrong state is passed to the callback
     code = SecureRandom.hex(16)
-    request.stubs(:params).returns({"code" => code, "state" => 43})
-    request.stubs(:path_info).returns("")
-    strategy.call!({"rack.session" => session})
+    request.stubs(:params).returns('code' => code, 'state' => 43)
+    request.stubs(:path_info).returns('')
+    strategy.call!('rack.session' => session)
 
     result = strategy.callback_phase
 
     assert result.kind_of?(Array)
-    assert result.first == 401, "Expecting unauthorized"
-  end
-
-
-  def test_option_client_auth_method
-    code = SecureRandom.hex(16)
-    state = SecureRandom.hex(16)
-    nonce = SecureRandom.hex(16)
-
-    opts = strategy.options.client_options
-    opts[:host] = "foobar.com"
-    strategy.options.issuer = "http://foobar.com"
-    strategy.options.client_auth_method = :not_basic
-    strategy.options.client_signing_alg = :RS256
-    strategy.options.client_jwk_signing_key = File.read('test/fixtures/jwks.json')
-
-    json_response = {access_token: 'test_access_token',
-                     id_token: File.read('test/fixtures/id_token.txt'),
-                     token_type: 'Bearer',
-    }.to_json
-    success = Struct.new(:status, :body).new(200, json_response)
-
-    request.stubs(:path_info).returns('')
-    strategy.call!({'rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce}})
-
-    id_token = stub('OpenIDConnect::ResponseObject::IdToken')
-    id_token.stubs(:verify!).with({:issuer => strategy.options.issuer, :client_id => @identifier, :nonce => nonce}).returns(true)
-    ::OpenIDConnect::ResponseObject::IdToken.stubs(:decode).returns(id_token)
-
-    HTTPClient.any_instance.stubs(:post).with(
-      "#{opts.scheme}://#{opts.host}:#{opts.port}#{opts.token_endpoint}",
-      {scope: 'openid', :grant_type => :client_credentials, :client_id => @identifier, :client_secret => @secret},
-      {}
-    ).returns(success)
-    #OpenIDConnect::Client.any_instance.stubs(:handle_success_response).with(success).returns(true)
-
-    assert(strategy.send :access_token)
+    assert result.first == 302, 'Expecting redirect to /auth/failure'
   end
 
   def test_public_key_with_jwks
@@ -383,9 +313,4 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     assert_equal OpenSSL::PKey::RSA, strategy.public_key.class
   end
 
-  def test_public_key_with_hmac
-    strategy.options.client_options.secret = 'secret'
-    strategy.options.client_signing_alg = :HS256
-    assert_equal strategy.options.client_options.secret, strategy.public_key
-  end
 end


### PR DESCRIPTION
Basically this pull request catches all errors in callback_phase and delegates handling to omni auth core via the OmniAuth::Strategy.fail! method. Thus the relaying party (RP) can decide how to proceed.
This also fixes the (almost un-maintainable) tests as far as possible.
Additionally some code clean up were made.